### PR TITLE
Add support for Lighthouse 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "nuwave/lighthouse": "^4.13"
+        "nuwave/lighthouse": "^4.13 || ^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Allowing Lighthouse 5 just works, but you might also want to point to https://github.com/mll-lab/graphql-php-scalars which also offers JSON and more and abandon this package on https://packagist.org/packages/marqant-lab/lighthouse-json in favor of mll-lab/graphql-php-scalars